### PR TITLE
Enemies now die when a crate moves over them

### DIFF
--- a/src/crateobj.rs
+++ b/src/crateobj.rs
@@ -12,7 +12,6 @@ use sdl2::rect::Point;
 //use sdl2::pixels;
 use crate::SDLCore;
 
-//#[derive(Copy, Clone)]
 pub struct Crate{
 	pos: Rect,
 	src: Rect,

--- a/src/enemy.rs
+++ b/src/enemy.rs
@@ -143,7 +143,7 @@ pub struct Enemy<'a> {
 				}
 			}
 		}
-		// this should all be copied into force move once its simplified. checking new bounds will solve the bug where enemies will continiously run into a wall. 
+		// this should all be copied into force move once its simplified. checking new bounds will solve the bug where enemies will continuously run into a wall.
 		let h_bounds_offset = (self.y() / TILE_SIZE as f64) as i32;
 		let w_bounds_offset = (self.x() / TILE_SIZE as f64) as i32;
 		let mut collisions: Vec<CollisionDecider> = Vec::with_capacity(5);
@@ -165,6 +165,14 @@ pub struct Enemy<'a> {
 				} else if map[(h as i32 + h_bounds_offset) as usize][(w as i32 + w_bounds_offset) as usize] == 2 {
 					let p_pos = self.pos();
 					if GameData::check_collision(&p_pos, &w_pos) {
+						for c in &game_data.crates{
+							if GameData::check_collision(&self.pos,&c.pos()){
+								if self.got_squished(w_pos, c.pos(), c.x_vel(), c.y_vel()) {
+									self.die();
+									continue;
+								}
+							}
+						}
 						collisions.push(self.collect_col(p_pos, self.pos().center(), w_pos));
 					}
 				}
@@ -184,6 +192,26 @@ pub struct Enemy<'a> {
 						 self.y() as i32 + (CENTER_H - y as i32),
 						 TILE_SIZE / 2, TILE_SIZE / 2);
 	}
+
+	 pub fn got_squished(&mut self, w_pos: Rect, c_pos: Rect, c_xvel: f64, c_yvel: f64) -> bool{
+		 // wall above and crate y_vel negative
+		 if self.pos().top() <= w_pos.bottom() && self.pos().bottom() >= c_pos.top() && c_yvel < 0.0{
+			 return true;
+		 }
+		 // wall below and crate y_vel positive
+		 else if self.pos().bottom() >= w_pos.top() && self.pos().top() >= c_pos.bottom() && c_yvel > 0.0{
+			 return true;
+		 }
+		 // wall left and crate x_vel negative
+		 else if self.pos().left() <= w_pos.right() && self.pos().right() >= c_pos.left() && c_xvel < 0.0{
+			 return true;
+		 }
+		 // wall right and crate x_vel positive
+		 else if self.pos().right() >= w_pos.left() && self.pos().left() <= c_pos.right() && c_xvel > 0.0{
+			 return true;
+		 }
+		 else { return false; }
+	 }
 
 	pub fn wander(&mut self, roll:i32) {
 
@@ -460,22 +488,22 @@ pub struct Enemy<'a> {
 	pub fn collect_col(&mut self, p_pos: Rect, p_center: Point, other_pos :Rect) -> CollisionDecider {
 		let distance = ((p_center.x() as f64 - other_pos.center().x() as f64).powf(2.0) + (p_center.y() as f64 - other_pos.center().y() as f64).powf(2.0)).sqrt();
 
-		// player above other
+		// enemy above other
 		if p_pos.bottom() >= other_pos.top() && p_center.y() < other_pos.top(){
 			let resolution = CollisionDecider::new(Down, distance as i32);
 			return resolution;
 		}
-		// player left of other
+		// enemy left of other
 		if p_pos.right() >= other_pos.left() && p_center.x() < other_pos.left() {
 			let resolution = CollisionDecider::new(Right, distance as i32);
 			return resolution;
 		}
-		// player below other
+		// enemy below other
 		if p_pos.top() <= other_pos.bottom() && p_center.y() > other_pos.bottom(){
 			let resolution = CollisionDecider::new(Up, distance as i32);
 			return resolution;
 		}
-		// player right of other
+		// enemy right of other
 		 else {
 			 let resolution = CollisionDecider::new(Left, distance as i32);
 			 return resolution;

--- a/src/enemy.rs
+++ b/src/enemy.rs
@@ -165,14 +165,6 @@ pub struct Enemy<'a> {
 				} else if map[(h as i32 + h_bounds_offset) as usize][(w as i32 + w_bounds_offset) as usize] == 2 {
 					let p_pos = self.pos();
 					if GameData::check_collision(&p_pos, &w_pos) {
-						for c in &game_data.crates{
-							if GameData::check_collision(&self.pos,&c.pos()){
-								if self.got_squished(w_pos, c.pos(), c.x_vel(), c.y_vel()) {
-									self.die();
-									continue;
-								}
-							}
-						}
 						collisions.push(self.collect_col(p_pos, self.pos().center(), w_pos));
 					}
 				}
@@ -180,6 +172,10 @@ pub struct Enemy<'a> {
 		}
 		for c in &game_data.crates{
 			if GameData::check_collision(&self.pos,&c.pos()){
+				// crate squishes enemy
+				if c.get_magnitude() > 0.0{
+					self.die();
+				}
 				collisions.push(self.collect_col(self.pos, self.pos().center(), c.pos()));
 			}
 		}
@@ -449,7 +445,7 @@ pub struct Enemy<'a> {
 	}
 
 	pub fn minus_hp(&mut self, dmg: i32) {
-		// self.hp -= dmg;
+		self.hp -= dmg;
 
 		if self.hp <= 0 {
 			self.die();

--- a/src/main.rs
+++ b/src/main.rs
@@ -497,7 +497,7 @@ impl ROGUELIKE {
 			// check crate collisions
 			for c in self.game_data.crates.iter_mut(){
 				if check_collision(&c.pos(), &enemy.pos()) && c.get_magnitude() != 0.0{
-					enemy.knockback(c.x().into(), c.y().into(), xbounds, ybounds);
+					enemy.projectile_knockback(c.x_vel(), c.y_vel());
 				}
 			}
 		}


### PR DESCRIPTION
- This solves the issue where an enemy can get pushed out of the map from a moving crate.
- Squishing an enemy would require a number of sorting checks that would not be attainable before the deadline